### PR TITLE
ci: remove bazelisk installation step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,6 @@ jobs:
   build_tutorial:
     runs-on: ubuntu-latest
     steps:
-      - name: Download Bazelisk
-        run: sudo curl -Lo /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
-
-      - name: Make Bazelisk executable
-        run: sudo chmod +x /usr/local/bin/bazel
-
-      - name: Verify Bazelisk installation
-        run: bazel --version
-
       - name: Install OS library dependencies
         run: sudo apt-get install -y libsasl2-dev libssl-dev libsnappy-dev libzstd-dev
 


### PR DESCRIPTION
Bazelisk is included in the Github Actions runner, so we don't need to download it ourselves.